### PR TITLE
feat: Migrate sequence MongoDB -> SQL w/ migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/node_modules
+yarn.lock
+.yarn.installed

--- a/core/sv_sequence.lua
+++ b/core/sv_sequence.lua
@@ -1,83 +1,185 @@
 local _cachedSeq = {}
-local _loadingPromises = {}
+local _loading = {}
+local _migrationComplete = false
+
+local function MigrateFromMongoDB()
+    if _migrationComplete then
+        return
+    end
+
+    local p = promise.new()
+
+    COMPONENTS.Logger:Info("Sequence", "Checking for unmigrated sequences in MongoDB...")
+
+    COMPONENTS.Database.Game:find({
+        collection = "sequence",
+        query = {
+            ["$or"] = {
+                { migrated = false },
+                { migrated = { ["$exists"] = false } }
+            }
+        },
+    }, function(success, results)
+        if not success then
+            COMPONENTS.Logger:Error("Sequence", "Failed to fetch sequences from MongoDB for migration")
+            p:resolve(false)
+            return
+        end
+
+        if #results == 0 then
+            COMPONENTS.Logger:Info("Sequence", "No unmigrated sequences found in MongoDB")
+            _migrationComplete = true
+            p:resolve(true)
+            return
+        end
+
+        COMPONENTS.Logger:Info("Sequence",
+            string.format("Found %d unmigrated sequences, starting migration...", #results))
+
+        local migratedCount = 0
+        local failedCount = 0
+
+        for _, doc in ipairs(results) do
+            if doc.key and doc.current then
+                local seqP = promise.new()
+
+                local inserted = MySQL.rawExecute.await(
+                    "INSERT INTO sequence (id, sequence) VALUES(?, ?) ON DUPLICATE KEY UPDATE sequence = GREATEST(sequence, VALUES(sequence))",
+                    { doc.key, doc.current }
+                )
+
+                if inserted then
+                    COMPONENTS.Database.Game:updateOne({
+                        collection = "sequence",
+                        query = { key = doc.key },
+                        update = { ["$set"] = { migrated = true } },
+                    }, function(updateSuccess)
+                        if updateSuccess then
+                            if not _cachedSeq[doc.key] or _cachedSeq[doc.key].sequence < doc.current then
+                                _cachedSeq[doc.key] = {
+                                    id = doc.key,
+                                    sequence = doc.current,
+                                    dirty = false,
+                                }
+                            end
+
+                            migratedCount = migratedCount + 1
+                            COMPONENTS.Logger:Trace("Sequence",
+                                string.format("Migrated sequence: ^2%s^7 (value=%d)", doc.key, doc.current))
+                        else
+                            failedCount = failedCount + 1
+                            COMPONENTS.Logger:Error("Sequence",
+                                string.format("Failed to mark sequence as migrated in MongoDB: %s", doc.key))
+                        end
+                        seqP:resolve()
+                    end)
+                else
+                    failedCount = failedCount + 1
+                    COMPONENTS.Logger:Error("Sequence", string.format("Failed to insert sequence into SQL: %s", doc.key))
+                    seqP:resolve()
+                end
+
+                Citizen.Await(seqP)
+            end
+        end
+
+        if migratedCount > 0 then
+            COMPONENTS.Logger:Info("Sequence",
+                string.format("Successfully migrated %d sequences from MongoDB to SQL", migratedCount))
+        end
+
+        if failedCount > 0 then
+            COMPONENTS.Logger:Warn("Sequence",
+                string.format("%d sequences failed to migrate (will retry on next startup)", failedCount))
+        end
+
+        _migrationComplete = (failedCount == 0)
+        p:resolve(true)
+    end)
+
+    return Citizen.Await(p)
+end
 
 COMPONENTS.Sequence = {
     Get = function(self, key)
-        if _cachedSeq[key] then
-            _cachedSeq[key].value = _cachedSeq[key].value + 1
+        if _cachedSeq[key] ~= nil then
+            _cachedSeq[key].sequence = _cachedSeq[key].sequence + 1
             _cachedSeq[key].dirty = true
-            return _cachedSeq[key].value
+            return _cachedSeq[key].sequence
+        else
+            _cachedSeq[key] = {
+                id = key,
+                sequence = 1,
+                dirty = true,
+            }
+            return 1
         end
-
-        if not _loadingPromises[key] then
-            local p = promise.new()
-            _loadingPromises[key] = p
-
-            COMPONENTS.Database.Game:findOne({
-                collection = "sequence",
-                query = { key = key },
-            }, function(success, results)
-                local currentValue = 1
-
-                if success and #results > 0 then
-                    currentValue = results[1].current + 1
-                end
-
-                _cachedSeq[key] = {
-                    value = currentValue,
-                    dirty = true,
-                }
-
-                COMPONENTS.Database.Game:updateOne({
-                    collection = "sequence",
-                    query = { key = key },
-                    update = { ["$set"] = { current = currentValue } },
-                    options = { upsert = true }
-                }, function(updateSuccess)
-                    if not updateSuccess then
-                        COMPONENTS.Logger:Error("Sequence", "Failed to immediately persist sequence number for key: " .. key)
-                    end
-                end)
-
-                p:resolve(_cachedSeq[key])
-                _loadingPromises[key] = nil
-            end)
-        end
-
-        local seqData = Citizen.Await(_loadingPromises[key])
-        return seqData.value
     end,
 
     Save = function(self)
+        local queries = {}
         for k, v in pairs(_cachedSeq) do
             if v.dirty then
-                local p = promise.new()
-                COMPONENTS.Database.Game:updateOne({
-                    collection = "sequence",
-                    query = { key = k },
-                    update = { ["$set"] = { current = v.value } },
-                    options = { upsert = true }
-                }, function(success)
-                    if success then
-                        COMPONENTS.Logger:Trace("Sequence", string.format("Saved Sequence: ^2%s^7 (value=%d)", k, v.value))
-                    else
-                        COMPONENTS.Logger:Error("Sequence", string.format("Failed saving Sequence: %s", k))
-                    end
-                    v.dirty = not success
-                    p:resolve(success)
-                end)
-                Citizen.Await(p)
+                table.insert(queries, {
+                    query =
+                    "INSERT INTO sequence (id, sequence) VALUES(?, ?) ON DUPLICATE KEY UPDATE sequence = VALUES(sequence)",
+                    values = {
+                        k,
+                        v.sequence,
+                    },
+                })
+
+                v.dirty = false
             end
+        end
+
+        if #queries > 0 then
+            MySQL.transaction(queries)
         end
     end,
 }
 
+AddEventHandler("Core:Server:StartupReady", function()
+    MySQL.rawExecute.await([[
+        CREATE TABLE IF NOT EXISTS `sequence` (
+            `id` VARCHAR(64) NOT NULL COLLATE 'utf8mb4_unicode_520_ci',
+            `sequence` BIGINT(20) NOT NULL DEFAULT '1',
+            PRIMARY KEY (`id`) USING BTREE
+        )
+        COLLATE='utf8mb4_unicode_520_ci'
+        ENGINE=InnoDB
+    ]])
+
+    COMPONENTS.Logger:Info("Sequence", "Ensured sequence table exists")
+
+    local t = MySQL.rawExecute.await("SELECT id, sequence FROM sequence")
+    if t then
+        for k, v in ipairs(t) do
+            _cachedSeq[v.id] = {
+                id = v.id,
+                sequence = v.sequence,
+                dirty = false,
+            }
+        end
+        COMPONENTS.Logger:Info("Sequence", string.format("Loaded %d sequences from SQL", #t))
+    end
+end)
+
 AddEventHandler("Core:Shared:Ready", function()
+    CreateThread(function()
+        MigrateFromMongoDB()
+    end)
+
     COMPONENTS.Tasks:Register("sequence_save", 1, function()
         COMPONENTS.Sequence:Save()
     end)
 end)
 
 AddEventHandler("Core:Server:ForceSave", function()
+    COMPONENTS.Sequence:Save()
+end)
+
+AddEventHandler("onResourceStop", function(resourceName)
+    if (GetCurrentResourceName() ~= resourceName) then return end
     COMPONENTS.Sequence:Save()
 end)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -11,6 +11,7 @@ client_scripts {
     'components/cl_*.lua',
 }
 
+server_script("@oxmysql/lib/MySQL.lua")
 server_scripts {
     'sh_init.lua',
     'sv_init.lua',


### PR DESCRIPTION
Old implementation used MongoDB (slower) and utilized promises, which leads to race conditions and duplicate values being returned when Sequence:Get is called twice before the original promise resolves

Includes automatic migration from MongoDB to SQL and automatic table creation for existing installs